### PR TITLE
Split websockets

### DIFF
--- a/sense_energy/__init__.py
+++ b/sense_energy/__init__.py
@@ -1,3 +1,4 @@
 from .sense_api import *
+from .sense_exceptions import *
 
 __version__ = "0.5.1"

--- a/sense_energy/sense_api.py
+++ b/sense_energy/sense_api.py
@@ -5,12 +5,12 @@ from time import time
 from datetime import datetime
 from requests.exceptions import ReadTimeout
 
-from sense_exceptions import *
-import ws_sync
+from .sense_exceptions import *
+from . import ws_sync
 if sys.version_info < (3, 6):
-    import ws_sync as websocket
+    from . import ws_sync as websocket
 else:
-    import ws_async as websocket
+    from . import ws_async as websocket
 
 API_URL = 'https://api.sense.com/apiservice/api/v1/'
 WS_URL = "wss://clientrt.sense.com/monitors/%s/realtimefeed?access_token=%s"

--- a/sense_energy/sense_exceptions.py
+++ b/sense_energy/sense_exceptions.py
@@ -1,0 +1,6 @@
+
+class SenseAPITimeoutException(Exception):
+    pass
+
+class SenseAuthenticationException(Exception):
+    pass

--- a/sense_energy/ws_async.py
+++ b/sense_energy/ws_async.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import websockets
-from sense_exceptions import SenseAPITimeoutException
+from .sense_exceptions import SenseAPITimeoutException
 
 data = 0
 async def get_realtime_stream(url, callback):
@@ -10,7 +10,7 @@ async def get_realtime_stream(url, callback):
     # hello, features, [updates,] data
     async with websockets.connect(url) as ws:
         while True:
-            message = await asyncio.wait_for(ws.recv(), timeout)
+            message = await ws.recv()
             result = json.loads(message)
             if result.get('type') == 'realtime_update':
                 data = result['payload']
@@ -28,4 +28,4 @@ def get_realtime(url, timeout):
         raise SenseAPITimeoutException("API websocket timed out")
                 
 def get_realtime_future(url, timeout, callback):
-    return get_realtime_stream(url, timeout, callback)
+    return get_realtime_stream(url, callback)

--- a/sense_energy/ws_async.py
+++ b/sense_energy/ws_async.py
@@ -1,0 +1,31 @@
+import asyncio
+import json
+import websockets
+from sense_exceptions import SenseAPITimeoutException
+
+data = 0
+async def get_realtime_stream(url, callback):
+    """ Reads realtime data from websocket"""
+    global data
+    # hello, features, [updates,] data
+    async with websockets.connect(url) as ws:
+        while True:
+            message = await asyncio.wait_for(ws.recv(), timeout)
+            result = json.loads(message)
+            if result.get('type') == 'realtime_update':
+                data = result['payload']
+                if callback: callback(data)
+                else: return
+    
+def get_realtime(url, timeout):
+    global data
+    try:
+        data = 0
+        asyncio.get_event_loop().run_until_complete(
+            asyncio.wait_for(get_realtime_stream(url, None), timeout))
+        return data
+    except asyncio.TimeoutError:
+        raise SenseAPITimeoutException("API websocket timed out")
+                
+def get_realtime_future(url, timeout, callback):
+    return get_realtime_stream(url, timeout, callback)

--- a/sense_energy/ws_sync.py
+++ b/sense_energy/ws_sync.py
@@ -1,0 +1,26 @@
+import json
+from websocket import create_connection
+from websocket._exceptions import WebSocketTimeoutException
+
+from sense_exceptions import SenseAPITimeoutException
+
+def get_realtime_stream(url, timeout):
+    """ Reads realtime data from websocket
+        Continues until loop broken"""
+    ws = 0
+    try:
+        ws = create_connection(url, timeout=timeout)
+        while True: # hello, features, [updates,] data
+            result = json.loads(ws.recv())
+            if result.get('type') == 'realtime_update':
+                yield result['payload']
+    except WebSocketTimeoutException:
+        raise SenseAPITimeoutException("API websocket timed out")
+    finally:
+        if ws: ws.close()
+
+def get_realtime(url, timeout):
+    return next(get_realtime_stream(url, timeout))
+
+def get_realtime_future(url, timeout, callback):
+    raise NotImplementedError("Not available in Python < 3.6")

--- a/sense_energy/ws_sync.py
+++ b/sense_energy/ws_sync.py
@@ -2,7 +2,7 @@ import json
 from websocket import create_connection
 from websocket._exceptions import WebSocketTimeoutException
 
-from sense_exceptions import SenseAPITimeoutException
+from .sense_exceptions import SenseAPITimeoutException
 
 def get_realtime_stream(url, timeout):
     """ Reads realtime data from websocket

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     install_requires=[
         'requests',
         'websocket-client',
+        'websockets;python_version>="3.6"',
     ],
     version = '0.5.1',
     description = 'API for the Sense Energy Monitor',


### PR DESCRIPTION
The "websockets" library is better and allows asynchronous handling of realtime data.  Unfortunately, it's only available on Python 3.6+

This change splits the websockets into separate files with the code that uses websockets isolated and not imported on earlier versions.  Compatibility with Python 2.7 is maintained with the new library being used when available