### PR TITLE
Allow custom certificate verification

### DIFF
--- a/sense_energy/asyncsenseable.py
+++ b/sense_energy/asyncsenseable.py
@@ -29,20 +29,19 @@ class ASyncSenseable(SenseableBase):
             wss_timeout=wss_timeout,
         )
 
-    async def authenticate(self, username, password, ssl_verify=""):
+    async def authenticate(self, username, password, ssl_verify=True, ssl_cafile=""):
         auth_data = {"email": username, "password": password}
 
-        if (ssl_verify is False):
-            # Disable ssl verification
+        # Use custom ssl verification, if specified
+        if (ssl_verify):
+            if (ssl_cafile != ""):
+                self.ssl_context = ssl.create_default_context(cafile=ssl_cafile)
+            else:
+                self.ssl_context = ssl.create_default_context()
+        else:
             self.ssl_context = ssl.create_default_context()
             self.ssl_context.check_hostname = False
             self.ssl_context.verify_mode = ssl.CERT_NONE
-        elif (type(ssl_verify) == str and ssl_verify != ""):
-            # Use custom ssl certificate file for verification
-            self.ssl_context = ssl.create_default_context(cafile=ssl_verify)
-        else:
-            # Use default ssl context
-            self.ssl_context = ssl.create_default_context()
 
         # Get auth token
         try:

--- a/sense_energy/asyncsenseable.py
+++ b/sense_energy/asyncsenseable.py
@@ -29,10 +29,14 @@ class ASyncSenseable(SenseableBase):
             wss_timeout=wss_timeout,
         )
 
-    async def authenticate(self, username, password):
+    async def authenticate(self, username, password, cafile=""):
         auth_data = {"email": username, "password": password}
 
-        self.ssl_context = ssl.create_default_context()
+        # Use custom certificate verification, if specified
+        if (cafile):
+            self.ssl_context = ssl.create_default_context(cafile=cafile)
+        else:
+            self.ssl_context = ssl.create_default_context()
 
         # Get auth token
         try:

--- a/sense_energy/asyncsenseable.py
+++ b/sense_energy/asyncsenseable.py
@@ -29,13 +29,19 @@ class ASyncSenseable(SenseableBase):
             wss_timeout=wss_timeout,
         )
 
-    async def authenticate(self, username, password, cafile=""):
+    async def authenticate(self, username, password, ssl_verify=""):
         auth_data = {"email": username, "password": password}
 
-        # Use custom certificate verification, if specified
-        if (cafile):
-            self.ssl_context = ssl.create_default_context(cafile=cafile)
+        if (ssl_verify is False):
+            # Disable ssl verification
+            self.ssl_context = ssl.create_default_context()
+            self.ssl_context.check_hostname = False
+            self.ssl_context.verify_mode = ssl.CERT_NONE
+        elif (type(ssl_verify) == str and ssl_verify != ""):
+            # Use custom ssl certificate file for verification
+            self.ssl_context = ssl.create_default_context(cafile=ssl_verify)
         else:
+            # Use default ssl context
             self.ssl_context = ssl.create_default_context()
 
         # Get auth token

--- a/sense_energy/asyncsenseable.py
+++ b/sense_energy/asyncsenseable.py
@@ -33,15 +33,14 @@ class ASyncSenseable(SenseableBase):
         auth_data = {"email": username, "password": password}
 
         # Use custom ssl verification, if specified
-        if (ssl_verify):
-            if (ssl_cafile != ""):
-                self.ssl_context = ssl.create_default_context(cafile=ssl_cafile)
-            else:
-                self.ssl_context = ssl.create_default_context()
-        else:
+        if not ssl_verify:
             self.ssl_context = ssl.create_default_context()
             self.ssl_context.check_hostname = False
             self.ssl_context.verify_mode = ssl.CERT_NONE
+        elif ssl_cafile:
+            self.ssl_context = ssl.create_default_context(cafile=ssl_cafile)
+        else:
+            self.ssl_context = ssl.create_default_context()
 
         # Get auth token
         try:

--- a/sense_energy/senseable.py
+++ b/sense_energy/senseable.py
@@ -23,7 +23,7 @@ class Senseable(SenseableBase):
         if not ssl_verify:
             self.s.verify = False
         elif ssl_cafile:
-            self.s.verify = ssl_cafile:
+            self.s.verify = ssl_cafile
 
         # Get auth token
         try:

--- a/sense_energy/senseable.py
+++ b/sense_energy/senseable.py
@@ -10,7 +10,7 @@ from .sense_exceptions import *
 
 class Senseable(SenseableBase):
 
-    def authenticate(self, username, password, verify=''):
+    def authenticate(self, username, password, ssl_verify=''):
         auth_data = {
             "email": username,
             "password": password
@@ -19,9 +19,9 @@ class Senseable(SenseableBase):
         # Create session
         self.s = requests.session()
 
-        # Use custom certificate verification, if specified
-        if (verify):
-            self.s.verify = verify
+        # Use custom ssl verification, if specified (can be bool or cert filename)
+        if (ssl_verify != ''):
+            self.s.verify = ssl_verify
 
         # Get auth token
         try:

--- a/sense_energy/senseable.py
+++ b/sense_energy/senseable.py
@@ -20,11 +20,10 @@ class Senseable(SenseableBase):
         self.s = requests.session()
 
         # Use custom ssl verification, if specified
-        if (ssl_verify):
-            if (ssl_cafile != ''):
-                self.s.verify = ssl_cafile
-        else:
+        if not ssl_verify:
             self.s.verify = False
+        elif ssl_cafile:
+            self.s.verify = ssl_cafile:
 
         # Get auth token
         try:

--- a/sense_energy/senseable.py
+++ b/sense_energy/senseable.py
@@ -10,7 +10,7 @@ from .sense_exceptions import *
 
 class Senseable(SenseableBase):
 
-    def authenticate(self, username, password, ssl_verify=''):
+    def authenticate(self, username, password, ssl_verify=True, ssl_cafile=''):
         auth_data = {
             "email": username,
             "password": password
@@ -19,9 +19,12 @@ class Senseable(SenseableBase):
         # Create session
         self.s = requests.session()
 
-        # Use custom ssl verification, if specified (can be bool or cert filename)
-        if (ssl_verify != ''):
-            self.s.verify = ssl_verify
+        # Use custom ssl verification, if specified
+        if (ssl_verify):
+            if (ssl_cafile != ''):
+                self.s.verify = ssl_cafile
+        else:
+            self.s.verify = False
 
         # Get auth token
         try:

--- a/sense_energy/senseable.py
+++ b/sense_energy/senseable.py
@@ -10,7 +10,7 @@ from .sense_exceptions import *
 
 class Senseable(SenseableBase):
 
-    def authenticate(self, username, password):
+    def authenticate(self, username, password, verify=''):
         auth_data = {
             "email": username,
             "password": password
@@ -18,6 +18,10 @@ class Senseable(SenseableBase):
         
         # Create session
         self.s = requests.session()
+
+        # Use custom certificate verification, if specified
+        if (verify):
+            self.s.verify = verify
 
         # Get auth token
         try:


### PR DESCRIPTION
Allow custom certificate verification when running behind a corporate proxy. See: https://requests.readthedocs.io/en/latest/user/advanced/#ssl-cert-verification