### PR TITLE
Expose more SenseableBase properties.

### DIFF
--- a/sense_energy/__init__.py
+++ b/sense_energy/__init__.py
@@ -8,4 +8,4 @@ if sys.version_info >= (3, 5):
     from .plug_instance import PlugInstance
     from .sense_link import SenseLink
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/sense_energy/sense_api.py
+++ b/sense_energy/sense_api.py
@@ -42,17 +42,17 @@ class SenseableBase(object):
         # create the auth header
         self.headers = {'Authorization': 'bearer {}'.format(
             self.sense_access_token)}
-        
+
 
     @property
     def devices(self):
         """Return devices."""
         return self._devices
-    
+
     def set_realtime(self, data):
         self._realtime = data
         self.last_realtime_call = time()
-        
+
     def get_realtime(self):
         return self._realtime     
 
@@ -74,35 +74,99 @@ class SenseableBase(object):
     
     @property
     def daily_usage(self):
-        return self.get_trend('DAY', False)
+        return self.get_trend('DAY', 'consumption')
 
     @property
     def daily_production(self):
-        return self.get_trend('DAY', True)
-    
+        return self.get_trend('DAY', 'production')
+
+    @property
+    def daily_production_pct(self):
+        return self.get_trend('DAY', 'production_pct')
+
+    @property
+    def daily_net_production(self):
+        return self.get_trend('DAY', 'net_production')
+
+    @property
+    def daily_from_grid(self):
+        return self.get_trend('DAY', 'from_grid')
+
+    @property
+    def daily_to_grid(self):
+        return self.get_trend('DAY', 'to_grid')
+
     @property
     def weekly_usage(self):
-        return self.get_trend('WEEK', False)
+        return self.get_trend('WEEK', 'consumption')
 
     @property
     def weekly_production(self):
-        return self.get_trend('WEEK', True)
-    
+        return self.get_trend('WEEK', 'production')
+
+    @property
+    def weekly_production_pct(self):
+        return self.get_trend('WEEK', 'production_pct')
+
+    @property
+    def weekly_net_production(self):
+        return self.get_trend('WEEK', 'net_production')
+
+    @property
+    def weekly_from_grid(self):
+        return self.get_trend('WEEK', 'from_grid')
+
+    @property
+    def weekly_to_grid(self):
+        return self.get_trend('WEEK', 'to_grid')
+
     @property
     def monthly_usage(self):
-        return self.get_trend('MONTH', False)
+        return self.get_trend('MONTH', 'consumption')
 
     @property
     def monthly_production(self):
-        return self.get_trend('MONTH', True)
-    
+        return self.get_trend('MONTH', 'production')
+
+    @property
+    def monthly_production_pct(self):
+        return self.get_trend('MONTH', 'production_pct')
+
+    @property
+    def monthly_net_production(self):
+        return self.get_trend('MONTH', 'net_production')
+
+    @property
+    def monthly_from_grid(self):
+        return self.get_trend('MONTH', 'from_grid')
+
+    @property
+    def monthly_to_grid(self):
+        return self.get_trend('MONTH', 'to_grid')
+
     @property
     def yearly_usage(self):
-        return self.get_trend('YEAR', False)
+        return self.get_trend('YEAR', 'consumption')
 
     @property
     def yearly_production(self):
-        return self.get_trend('YEAR', True)
+        return self.get_trend('YEAR', 'production')
+
+    @property
+    def yearly_production_pct(self):
+        return self.get_trend('YEAR', 'production_pct')
+
+    @property
+    def yearly_net_production(self):
+        return self.get_trend('YEAR', 'net_production')
+
+    @property
+    def yearly_from_grid(self):
+        return self.get_trend('YEAR', 'from_grid')
+
+    @property
+    def yearly_to_grid(self):
+        return self.get_trend('YEAR', 'to_grid')
 
     @property
     def active_devices(self):

--- a/sense_energy/sense_api.py
+++ b/sense_energy/sense_api.py
@@ -188,7 +188,7 @@ class SenseableBase(object):
     def active_devices(self):
         return [d['name'] for d in self._realtime.get('devices', {})]
 
-    def get_trend(self, scale, key='production'):
+    def get_trend(self, scale, key):
         if key not in self._trend_data[scale]: return 0
         # Perform a check for a valid type
         if not isinstance(self._trend_data[scale][key], (dict, float, int)): return 0

--- a/sense_energy/sense_api.py
+++ b/sense_energy/sense_api.py
@@ -108,12 +108,16 @@ class SenseableBase(object):
     def active_devices(self):
         return [d['name'] for d in self._realtime.get('devices', {})]
 
-    def get_trend(self, scale, is_production):
-        key = "production" if is_production else "consumption"       
+    def get_trend(self, scale, key='production'):
         if key not in self._trend_data[scale]: return 0
-        total = self._trend_data[scale][key].get('total', 0)
+        # Perform a check for a valid type
+        if not isinstance(self._trend_data[scale][key], (dict, float, int)): return 0
+        if isinstance(self._trend_data[scale][key], dict):
+          total = self._trend_data[scale][key].get('total', 0)
+        else:
+          total = self._trend_data[scale][key]
         if scale == 'WEEK' or scale == 'MONTH':
-            return total + self.get_trend('DAY', is_production)
+            return total + self.get_trend('DAY', key)
         if scale == 'YEAR':
-            return total + self.get_trend('MONTH', is_production)
+            return total + self.get_trend('MONTH', key)
         return total

--- a/sense_energy/sense_api.py
+++ b/sense_energy/sense_api.py
@@ -196,8 +196,4 @@ class SenseableBase(object):
           total = self._trend_data[scale][key].get('total', 0)
         else:
           total = self._trend_data[scale][key]
-        if scale == 'WEEK' or scale == 'MONTH':
-            return total + self.get_trend('DAY', key)
-        if scale == 'YEAR':
-            return total + self.get_trend('MONTH', key)
         return total

--- a/sense_energy/sense_api.py
+++ b/sense_energy/sense_api.py
@@ -25,10 +25,10 @@ class SenseableBase(object):
         self.wss_timeout = wss_timeout
         self.rate_limit = RATE_LIMIT
         self.last_realtime_call = 0
-        
+
         self._realtime = {}
         self._devices = []
-        self._trend_data = {}        
+        self._trend_data = {}
         for scale in valid_scales: self._trend_data[scale] = {}
 
         if username and password:
@@ -43,7 +43,6 @@ class SenseableBase(object):
         self.headers = {'Authorization': 'bearer {}'.format(
             self.sense_access_token)}
 
-
     @property
     def devices(self):
         """Return devices."""
@@ -54,7 +53,7 @@ class SenseableBase(object):
         self.last_realtime_call = time()
 
     def get_realtime(self):
-        return self._realtime     
+        return self._realtime
 
     @property
     def active_power(self):
@@ -67,11 +66,11 @@ class SenseableBase(object):
     @property
     def active_voltage(self):
         return self._realtime.get('voltage', [])
-    
+
     @property
     def active_frequency(self):
         return self._realtime.get('hz', 0)
-    
+
     @property
     def daily_usage(self):
         return self.get_trend('DAY', 'consumption')
@@ -189,11 +188,12 @@ class SenseableBase(object):
         return [d['name'] for d in self._realtime.get('devices', {})]
 
     def get_trend(self, scale, key):
+        key = 'consumption' if key == 'usage' else key
         if key not in self._trend_data[scale]: return 0
         # Perform a check for a valid type
         if not isinstance(self._trend_data[scale][key], (dict, float, int)): return 0
         if isinstance(self._trend_data[scale][key], dict):
-          total = self._trend_data[scale][key].get('total', 0)
+            total = self._trend_data[scale][key].get('total', 0)
         else:
-          total = self._trend_data[scale][key]
+            total = self._trend_data[scale][key]
         return total

--- a/sense_energy/sense_api.py
+++ b/sense_energy/sense_api.py
@@ -97,6 +97,10 @@ class SenseableBase(object):
         return self.get_trend('DAY', 'to_grid')
 
     @property
+    def daily_solar_powered(self):
+        return self.get_trend('DAY', 'solar_powered')
+
+    @property
     def weekly_usage(self):
         return self.get_trend('WEEK', 'consumption')
 
@@ -119,6 +123,10 @@ class SenseableBase(object):
     @property
     def weekly_to_grid(self):
         return self.get_trend('WEEK', 'to_grid')
+
+    @property
+    def weekly_solar_powered(self):
+        return self.get_trend('WEEK', 'solar_powered')
 
     @property
     def monthly_usage(self):
@@ -145,6 +153,10 @@ class SenseableBase(object):
         return self.get_trend('MONTH', 'to_grid')
 
     @property
+    def monthly_solar_powered(self):
+        return self.get_trend('MONTH', 'solar_powered')
+
+    @property
     def yearly_usage(self):
         return self.get_trend('YEAR', 'consumption')
 
@@ -167,6 +179,10 @@ class SenseableBase(object):
     @property
     def yearly_to_grid(self):
         return self.get_trend('YEAR', 'to_grid')
+
+    @property
+    def yearly_solar_powered(self):
+        return self.get_trend('YEAR', 'solar_powered')
 
     @property
     def active_devices(self):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author = 'scottbonline',
     author_email = 'scottbonline@gmail.com',
     url = 'https://github.com/scottbonline/sense',
-    download_url = 'https://github.com/scottbonline/sense/archive/0.9.0.tar.gz', 
+    download_url = 'https://github.com/scottbonline/sense/archive/0.9.1.tar.gz',
     keywords = ['sense', 'energy', 'api', 'pytest'], 
     classifiers = [
         'Programming Language :: Python :: 2',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         'websockets;python_version>="3.5"',
         'aiohttp;python_version>="3.5"',
     ], 
-    version = '0.9.0',
+    version = '0.9.1',
     description = 'API for the Sense Energy Monitor',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
In order to expose additional information to be used with the new Home Assistant Energy dashboard, the following changes were made.

* Refactored get_trend() to handle more than two keys from self._trend_data.
  - 'key' is now a keyword argument on get_trend() with a default of "consumption", no longer is set as a boolean inside the function.
  - Perform type check on data referenced by key, ensure type is ...
    - dict (for consumption/production)
    - float (for to/from_grid and net_production properties)
    - int (for production_pct).

* Converted existing True/False parameters on self.get_trend() calls to explicit key names.

* Added new properties exposing existing information already in self._trend_data for daily scale and above.
  - production_pct
  - net_production
  - from_grid
  - to_grid

* Also chomped some whitespace, because why not.