### PR TITLE
Add backwards compatibility to get_trend().

### DIFF
--- a/sense_energy/__init__.py
+++ b/sense_energy/__init__.py
@@ -8,4 +8,4 @@ if sys.version_info >= (3, 5):
     from .plug_instance import PlugInstance
     from .sense_link import SenseLink
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"

--- a/sense_energy/sense_api.py
+++ b/sense_energy/sense_api.py
@@ -188,7 +188,10 @@ class SenseableBase(object):
         return [d['name'] for d in self._realtime.get('devices', {})]
 
     def get_trend(self, scale, key):
-        key = 'consumption' if key == 'usage' else key
+        if isinstance(key, bool):
+            key = 'production' if key is True else 'consumption'
+        else:
+            key = 'consumption' if key == 'usage' else key
         if key not in self._trend_data[scale]: return 0
         # Perform a check for a valid type
         if not isinstance(self._trend_data[scale][key], (dict, float, int)): return 0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         'websockets;python_version>="3.5"',
         'aiohttp;python_version>="3.5"',
     ], 
-    version = '0.9.1',
+    version = '0.9.2',
     description = 'API for the Sense Energy Monitor',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
New changes to get_trend() break the existing Home Assistant sensor when used with the recently published version.

PR adds logic to handle the prior Boolean type parameter properly.

```
>>> sense.get_trend('MONTH', 'usage')
541.4076
>>> sense.get_trend('MONTH', False)
541.4076
>>> sense.get_trend('MONTH', 'production')
178.5108
>>> sense.get_trend('MONTH', True)
178.5108
```