### PR TITLE
Fix api_call and modify get_all_usage_data 

### DIFF
--- a/sense_energy/senseable.py
+++ b/sense_energy/senseable.py
@@ -84,7 +84,7 @@ class Senseable(SenseableBase):
             return self.s.get(API_URL + url,
                               headers=self.headers,
                               timeout=self.api_timeout,
-                              data=payload).json()
+                              params=payload).json()
         except ReadTimeout:
             raise SenseAPITimeoutException("API call timed out")   
 

--- a/sense_energy/senseable.py
+++ b/sense_energy/senseable.py
@@ -114,8 +114,21 @@ class Senseable(SenseableBase):
         return self.api_call('app/monitors/%s/devices/%s' %
                              (self.sense_monitor_id, device_id))
 
-    def get_all_usage_data(self):
-        payload = {'n_items': 30}
+    def get_all_usage_data(self, payload = {'n_items': 30}):
+        """Gets usage data by device
+
+        Args:
+            payload (dict, optional): known params are:
+                n_items: the number of items to return
+                device_id: limit results to a specific device_id
+                prior_to_item:. date in format YYYY-MM-DDTHH:MM:SS.mmmZ 
+                rollup: ?
+                
+                Defaults to {'n_items': 30}.
+
+        Returns:
+            dict: usage data
+        """
         # lots of info in here to be parsed out
         return self.api_call('users/%s/timeline' %
                           (self.sense_user_id), payload)


### PR DESCRIPTION
1) changed `data` to `params` in get call of api_call.  Now params sent to the API call are passed to the API in the URL.

2) in get_all_usage_data, moved payload to the definition so it can be passed in.

3) added docstring to get_all_usage data with a list of some known params.