### PR TITLE
Rate limit calls strictly based on time between calls to the API

### DIFF
--- a/sense_energy/asyncsenseable.py
+++ b/sense_energy/asyncsenseable.py
@@ -124,9 +124,10 @@ class ASyncSenseable(SenseableBase):
     async def update_realtime(self):
         """Update the realtime data (device status and current power)."""
         # rate limit API calls
-        if self._realtime and self.rate_limit and self.last_realtime_call + self.rate_limit > time():
+        now = time()
+        if self._realtime and self.rate_limit and self.last_realtime_call + self.rate_limit > now:
             return self._realtime
-        self.last_realtime_call = time()
+        self.last_realtime_call = now
         await self.async_realtime_stream(single=True)
 
     async def async_realtime_stream(self, callback=None, single=False):

--- a/sense_energy/sense_api.py
+++ b/sense_energy/sense_api.py
@@ -84,7 +84,6 @@ class SenseableBase(object):
     def _set_realtime(self, data):
         """Sets the realtime data structure."""
         self._realtime = data
-        self.last_realtime_call = time()
 
     def get_realtime(self):
         """Return the raw realtime data structure."""

--- a/sense_energy/senseable.py
+++ b/sense_energy/senseable.py
@@ -129,8 +129,10 @@ class Senseable(SenseableBase):
     def update_realtime(self):
         """Update the realtime data (device status and current power)."""
         # rate limit API calls
-        if self._realtime and self.rate_limit and self.last_realtime_call + self.rate_limit > time():
+        now = time()
+        if self._realtime and self.rate_limit and self.last_realtime_call + self.rate_limit > now:
             return self._realtime
+        self.last_realtime_call = now
         url = WS_URL % (self.sense_monitor_id, self.sense_access_token)
         next(self.get_realtime_stream())
 


### PR DESCRIPTION
Rate limit calls strictly based on time between calls to the API rather than a mix between call and completion times. This addresses the issue of an upper level app receiving updates at half the requested rate when periodic calls are made at the configured rate_limit.

This issue can easily be seen in Home Assistant, which sets the rate_limit to 60, and has a periodic timer that makes an async API call every 60 seconds to request updated values. Since each update takes 1-2 seconds each to complete, the result is that every other call is ignored and data from the previous call is returned instead.

NB: The caching of current time (variable now) is required to prevent a race condition with clock second turnover.