### PR TITLE
Optimize processing of websocket messages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ setup(
     name = 'sense_energy',
     packages = ['sense_energy'], 
     install_requires=[
+        'async_timeout>=3.0.1',
+        'orjson',
         'requests',
         'websocket-client',
         'websockets;python_version>="3.5"',


### PR DESCRIPTION
Switch to asyncio.timeout/async_timeout to avoid task creation
- asyncio.wait_for creates a task which is not needed here
- the wait_for implementation will eventually be replaced but not until 3.12 in https://github.com/python/cpython/pull/98518

Use orjson for parsing json