### PR TITLE
Avoid None/float error when reading from_grid

### DIFF
--- a/sense_energy/sense_api.py
+++ b/sense_energy/sense_api.py
@@ -298,6 +298,8 @@ class SenseableBase(object):
         update = self.trend_start(scale)
         if not update:
             return None
+        if scale not in self._trend_data or "from_grid" not in self._trend_data[scale]:
+            return None
         val = self._trend_data[scale]["from_grid"] / 100.0
         seconds = int(val)
         microseconds = int((val % 1) * 1000000)


### PR DESCRIPTION
Reported via https://github.com/home-assistant/core/issues/139533

```
  File "/usr/local/lib/python3.13/site-packages/sense_energy/sense_api.py", line 102, in _update_device_trends
    update = self.trend_update(scale)
  File "/usr/local/lib/python3.13/site-packages/sense_energy/sense_api.py", line 301, in trend_update
    val = self._trend_data[scale]["from_grid"] / 100.0
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
TypeError: unsupported operand type(s) for /: 'NoneType' and 'float'
```
