### PR TITLE
use realtime update API for single updates

### DIFF
--- a/sense_energy/asyncsenseable.py
+++ b/sense_energy/asyncsenseable.py
@@ -311,9 +311,11 @@ class ASyncSenseable(SenseableBase):
 
     async def supports_realtime_update_api(self) -> bool:
         """Returns whether a device supports the /app/<monitor_id>/realtime_update API."""
-        await self.get_sw_version()
 
-        if self._sw_version and self._sw_version >= MIN_VERSION_REALTIME_UPDATE_API:
+        # Assume that software version will not downgrade; if set, don't check again
+        if self._sw_version >= MIN_VERSION_REALTIME_UPDATE_API:
             return True
         else:
-            return False
+            await self.get_sw_version()
+
+            return self._sw_version >= MIN_VERSION_REALTIME_UPDATE_API

--- a/sense_energy/asyncsenseable.py
+++ b/sense_energy/asyncsenseable.py
@@ -155,7 +155,11 @@ class ASyncSenseable(SenseableBase):
             return self._realtime
         self.last_realtime_call = now
         try:
-            await self.async_realtime_stream(single=True)
+            if await self.supports_realtime_update_api():
+                data = await self.get_realtime_update()
+                self._set_realtime(data)
+            else:
+                await self.async_realtime_stream(single=True)
         except SenseAuthenticationException as e:
             if retry:
                 await self.renew_auth()
@@ -243,6 +247,10 @@ class ASyncSenseable(SenseableBase):
             self._monitor = json["monitor_overview"]["monitor"]
         return self._monitor
 
+    async def get_monitor_info(self):
+        """View info on monitor & device detection status from API."""
+        return await self._api_call(f"app/monitors/{self.sense_monitor_id}/status")
+
     async def fetch_devices(self) -> None:
         """Fetch discovered devices from API."""
         json = await self._api_call(f"app/monitors/{self.sense_monitor_id}/devices/overview")
@@ -287,3 +295,25 @@ class ASyncSenseable(SenseableBase):
         Use fetch_devices and sense.devices instead."""
         json = self._api_call(f"monitors/{self.sense_monitor_id}/devices/overview")
         return await json["devices"]
+
+    async def get_realtime_update(self):
+        """Get a realtime update for a device from API."""
+        return await self._api_call(f"app/{self.sense_monitor_id}/realtime_update")
+
+    async def get_sw_version(self):
+        """Get the currently installed software version on a device from API."""
+        now = time()
+        if not self._sw_version or now > self.last_sw_version_check + SW_VERSION_CHECK_INTERVAL:
+            data = await self.get_monitor_info()
+            self._sw_version = data["monitor_info"]["version"]
+            self.last_sw_version_check = now
+        return self._sw_version
+
+    async def supports_realtime_update_api(self) -> bool:
+        """Returns whether a device supports the /app/<monitor_id>/realtime_update API."""
+        await self.get_sw_version()
+
+        if self._sw_version and self._sw_version >= MIN_VERSION_REALTIME_UPDATE_API:
+            return True
+        else:
+            return False

--- a/sense_energy/sense_api.py
+++ b/sense_energy/sense_api.py
@@ -11,6 +11,9 @@ API_TIMEOUT = 5
 WSS_TIMEOUT = 5
 RATE_LIMIT = 60
 
+MIN_VERSION_REALTIME_UPDATE_API = "1.64"
+SW_VERSION_CHECK_INTERVAL = 86400 # 1 day
+
 
 class Scale(Enum):
     DAY = auto()
@@ -70,6 +73,8 @@ class SenseableBase(object):
 
         if username and password:
             self.authenticate(username, password)
+
+        self._sw_version = ""
 
     def load_auth(self, access_token: str, user_id: str, device_id: str, refresh_token: str):
         """Load the authentication data from a previous session."""

--- a/sense_energy/senseable.py
+++ b/sense_energy/senseable.py
@@ -272,9 +272,11 @@ class Senseable(SenseableBase):
 
     def supports_realtime_update_api(self) -> bool:
         """Returns whether a device supports the /app/<monitor_id>/realtime_update API."""
-        self.get_sw_version()
 
-        if self._sw_version and self._sw_version >= MIN_VERSION_REALTIME_UPDATE_API:
+        # Assume that software version will not downgrade; if set, don't check again
+        if self._sw_version >= MIN_VERSION_REALTIME_UPDATE_API:
             return True
         else:
-            return False
+            self.get_sw_version()
+
+            return self._sw_version >= MIN_VERSION_REALTIME_UPDATE_API

--- a/sense_energy/senseable.py
+++ b/sense_energy/senseable.py
@@ -137,7 +137,11 @@ class Senseable(SenseableBase):
             return self._realtime
         self.last_realtime_call = now
         try:
-            next(self.get_realtime_stream())
+            if self.supports_realtime_update_api():
+                data = self.get_realtime_update()
+                self._set_realtime(data)
+            else:
+                next(self.get_realtime_stream())
         except SenseAuthenticationException as e:
             if retry:
                 self.renew_auth()
@@ -252,3 +256,25 @@ class Senseable(SenseableBase):
         """
         # lots of info in here to be parsed out
         return self._api_call(f"users/{self.sense_user_id}/timeline", payload)
+
+    def get_realtime_update(self):
+        """Get a realtime update for a device from API."""
+        return self._api_call(f"app/{self.sense_monitor_id}/realtime_update")
+
+    def get_sw_version(self):
+        """Get the currently installed software version on a device from API."""
+        now = time()
+        if not self._sw_version or now > self.last_sw_version_check + SW_VERSION_CHECK_INTERVAL:
+            data = self.get_monitor_info()
+            self._sw_version = data["monitor_info"]["version"]
+            self.last_sw_version_check = now
+        return self._sw_version
+
+    def supports_realtime_update_api(self) -> bool:
+        """Returns whether a device supports the /app/<monitor_id>/realtime_update API."""
+        self.get_sw_version()
+
+        if self._sw_version and self._sw_version >= MIN_VERSION_REALTIME_UPDATE_API:
+            return True
+        else:
+            return False


### PR DESCRIPTION
I'm submitting this PR on behalf of Sense.

Sense now provides a dedicated endpoint for fetching a single realtime update, and it will work for all monitors on Sense firmware version 1.64 or later. Sense would like to migrate websocket clients to the new endpoint to save resources on our side, as maintaining a websocket connection is more resource-intensive than responding to an HTTP query.

I've tested the code on my side via CLI, using both the sync and async APIs (only sync shown below, but I conducted equivalent testing for async):

```
>>> from sense_energy.senseable import Senseable
>>> sense = Senseable()
>>> sense.authenticate(username, password)
>>> sense.update_realtime()
>>> print(sense.__dict__)
```

My testing validated that the firmware version is checked when appropriate (I opted for a daily update, since firmware updates occur at most once per day), that only units running sufficiently new firmware will use the new endpoint, and that the data returned from the endpoint is (mostly) in the same format; the `epoch` key is missing from the new output, and the `c` key is missing for each entry in the `devices` list - but it doesn't seem either of those are relied on.