### PR TITLE
chore: replace deprecated endpoint

### DIFF
--- a/sense_energy/asyncsenseable.py
+++ b/sense_energy/asyncsenseable.py
@@ -227,11 +227,26 @@ class ASyncSenseable(SenseableBase):
         Optionally set a date to fetch data from."""
         if not dt:
             dt = datetime.now(timezone.utc)
-        json = self._api_call(
-            f"app/history/trends?monitor_id={self.sense_monitor_id}"
-            + f"&device_id=always_on&scale={scale.name}&start={dt.strftime('%Y-%m-%dT%H:%M:%S')}"
+        
+        # Ensure monitor data is available to check solar configuration
+        if not self._monitor:
+            await self.get_monitor_data()
+        
+        usage_data = await self._api_call(
+            f"app/monitors/{self.sense_monitor_id}/history/usage"
+            + f"?scale={scale.name}&start={dt.strftime('%Y-%m-%dT%H:%M:%S')}"
         )
-        self._trend_data[scale] = await json
+        
+        # Get solar data if solar is configured
+        solar_data = None
+        if self._monitor.get("solar_configured"):
+            solar_data = await self._api_call(
+                f"app/monitors/{self.sense_monitor_id}/history/usage/solar"
+                + f"?scale={scale.name}&start={dt.strftime('%Y-%m-%dT%H:%M:%S')}"
+            )
+        
+        # Transform to legacy format for backward compatibility
+        self._trend_data[scale] = self._transform_usage_response(usage_data, solar_data)
         self._update_device_trends(scale)
 
     async def update_trend_data(self, dt: datetime = None) -> None:

--- a/sense_energy/sense_api.py
+++ b/sense_energy/sense_api.py
@@ -101,8 +101,54 @@ class SenseableBase(object):
             "Authorization": "bearer {}".format(self.sense_access_token),
         }
 
+    @staticmethod
+    def _transform_usage_response(usage_data: dict, solar_data: dict = None) -> dict:
+        """Transform new API response format to legacy format."""
+        legacy_format = {
+            "start": usage_data.get("start"),
+            "consumption": {
+                "total": usage_data.get("consumption", {}).get("usage_total_kwh", 0),
+                "devices": [
+                    {
+                        "id": d["id"],
+                        "name": d["name"],
+                        "icon": d["icon"],
+                        "total_kwh": d.get("consumption", {}).get("usage_total_kwh", 0)
+                    }
+                    for d in usage_data.get("device_breakdown", [])
+                ]
+            }
+        }
+        
+        if solar_data and "total" in solar_data:
+            solar_total = solar_data["total"]
+            legacy_format["from_grid"] = solar_total.get("from_grid_kwh")
+            legacy_format["to_grid"] = solar_total.get("to_grid_kwh")
+            legacy_format["production"] = {
+                "total": solar_total.get("production_kwh", 0)
+            }
+            legacy_format["solar_powered"] = solar_total.get("solar_percentage")
+            legacy_format["net_production"] = solar_total.get("net_kwh")
+            
+            consumption_total = legacy_format["consumption"]["total"]
+            production_total = solar_total.get("production_kwh", 0)
+            if consumption_total > 0:
+                legacy_format["production_pct"] = round(production_total / consumption_total * 100)
+            else:
+                legacy_format["production_pct"] = 100 if production_total > 0 else 0
+        else:
+            legacy_format["from_grid"] = None
+            legacy_format["to_grid"] = None
+            legacy_format["production"] = {"total": 0}
+            legacy_format["solar_powered"] = None
+            legacy_format["net_production"] = None
+            legacy_format["production_pct"] = None
+        
+        return legacy_format
+
     def _update_device_trends(self, scale: Scale):
-        if not self._trend_data[scale]["consumption"].get("devices"):
+        consumption = self._trend_data[scale].get("consumption", {})
+        if not consumption.get("devices"):
             return
         if update := self.trend_update(scale):
             if update < self._trend_data_updated[scale]:

--- a/sense_energy/senseable.py
+++ b/sense_energy/senseable.py
@@ -199,9 +199,26 @@ class Senseable(SenseableBase):
         Optionally set a date to fetch data from."""
         if not dt:
             dt = datetime.now(timezone.utc)
-        self._trend_data[scale] = self._api_call(
-            f"app/history/trends?monitor_id={self.sense_monitor_id}&scale={scale.name}&start={dt.strftime('%Y-%m-%dT%H:%M:%S')}"
+        
+        # Ensure monitor data is available to check solar configuration
+        if not self._monitor:
+            self.get_monitor_data()
+        
+        usage_data = self._api_call(
+            f"app/monitors/{self.sense_monitor_id}/history/usage"
+            + f"?scale={scale.name}&start={dt.strftime('%Y-%m-%dT%H:%M:%S')}"
         )
+        
+        # Get solar data if solar is configured
+        solar_data = None
+        if self._monitor.get("solar_configured"):
+            solar_data = self._api_call(
+                f"app/monitors/{self.sense_monitor_id}/history/usage/solar"
+                + f"?scale={scale.name}&start={dt.strftime('%Y-%m-%dT%H:%M:%S')}"
+            )
+        
+        # Transform to legacy format for backward compatibility
+        self._trend_data[scale] = self._transform_usage_response(usage_data, solar_data)
         self._update_device_trends(scale)
 
     def update_trend_data(self, dt=None):


### PR DESCRIPTION
This is a courtesy PR to replace a deprecated endpoint with new APIs.

Sense has deprecated the /trends endpoint and will remove it at a future date. There are two new endpoints that can be used to replace it. A transformation function was added to ensure backwards compatibility.

1. /app/monitors/{monitor_id}/history/usage
2. /app/monitors/{monitor_id}/history/usage/solar

I tested this change via CLI:

**Synchronous API:**
```
>>> from sense_energy.senseable import Senseable
>>>
>>> sense = Senseable()
>>> sense.authenticate(username, password)
>>> sense.update_trend_data()
>>> print(sense._trend_data)
```

**Async API:**
```
>>> import asyncio
>>> from sense_energy import ASyncSenseable
>>> import aiohttp
>>> 
>>> async def test():
...     async with aiohttp.ClientSession() as session:
...         sense = ASyncSenseable(client_session=session)
...         await sense.authenticate("username", "password")
...         await sense.update_trend_data()
...         print(sense._trend_data)
... 
>>> asyncio.run(test())
```